### PR TITLE
Option to limit multiprocessing for the node workers

### DIFF
--- a/tad/consensus/blockchain.py
+++ b/tad/consensus/blockchain.py
@@ -6,6 +6,8 @@ from concurrent.futures.process import ProcessPoolExecutor
 from enum import Enum
 from typing import Dict, List, Optional, Set, Tuple, Union
 
+from tad.util.default_root import DEFAULT_ROOT_PATH
+from tad.util.config import load_config
 from tad.consensus.block_body_validation import validate_block_body
 from tad.consensus.block_header_validation import validate_finished_header_block, validate_unfinished_header_block
 from tad.consensus.block_record import BlockRecord
@@ -101,7 +103,10 @@ class Blockchain(BlockchainInterface):
         cpu_count = multiprocessing.cpu_count()
         if cpu_count > 61:
             cpu_count = 61  # Windows Server 2016 has an issue https://bugs.python.org/issue26903
+        config = load_config(DEFAULT_ROOT_PATH, "config.yaml")
         num_workers = max(cpu_count - 2, 1)
+        if 'multiprocessing_limit' in config.keys():
+            num_workers = min(num_workers, int(config["multiprocessing_limit"]));
         self.pool = ProcessPoolExecutor(max_workers=num_workers)
         log.info(f"Started {num_workers} processes for block validation")
 

--- a/tad/util/initial-config.yaml
+++ b/tad/util/initial-config.yaml
@@ -7,6 +7,12 @@ daemon_port: 4400
 inbound_rate_limit_percent: 100
 outbound_rate_limit_percent: 30
 
+# Limit the number of start_full_node worker processes to reduce ram and cpu usage
+# This allows users to farm more forks without running out of ram
+# Setting this too low reduces sync speed, but a synced node can stay synced with a multiprocessing_limit of 2
+# A value higher than 61 takes no effect, as chia limits the workers to 61 (windows server related python bug)
+# multiprocessing_limit: 4
+
 network_overrides: &network_overrides
   constants:
     mainnet:


### PR DESCRIPTION
As suggested by @grayfallstown  this feature allows limiting unnecessary memory overhead for the system with many cores

Closes issue #12 